### PR TITLE
Clang-format setup for ETC

### DIFF
--- a/ETC/.clang-format
+++ b/ETC/.clang-format
@@ -1,0 +1,17 @@
+# Options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Google
+AccessModifierOffset: -4
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Attach
+ColumnLimit: 100
+ContinuationIndentWidth: 4
+IndentWidth: 4
+UseTab: Never
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 1
+SpacesBeforeTrailingComments: 2
+PointerAlignment: Left
+PackConstructorInitializers: Never

--- a/ETC/main.cpp
+++ b/ETC/main.cpp
@@ -3,12 +3,12 @@
 //
 
 #if !DEVICE_CAN
-#error [NOT_SUPPORTED] CAN not supported for this target
+#error[NOT_SUPPORTED] CAN not supported for this target
 #endif
 
+#include "mbed.h"
 #include "src/can_wrapper.h"
 #include "src/etc_controller.h"
-#include "mbed.h"
 
 EventFlags global_events;
 ETCController* etc_handle;
@@ -22,28 +22,30 @@ CANWrapper* can_handle;
  * @return 1 if error
  */
 void do_can_processing() {
- while (true) {
-  // Wait for any event flag to be set (defined in the can wrapper class)
-  uint32_t triggered_flags = global_events.wait_any(can_handle->THROTTLE_FLAG | can_handle->STATE_FLAG | can_handle->SYNC_FLAG | can_handle->RX_FLAG);
+    while (true) {
+        // Wait for any event flag to be set (defined in the can wrapper class)
+        uint32_t triggered_flags =
+            global_events.wait_any(can_handle->THROTTLE_FLAG | can_handle->STATE_FLAG |
+                                   can_handle->SYNC_FLAG | can_handle->RX_FLAG);
 
-  /* Check for every event, process and then clear the corresponding flag */
-  if (triggered_flags & can_handle->THROTTLE_FLAG) {
-   can_handle->sendThrottle();
-   global_events.clear(can_handle->THROTTLE_FLAG);
-  }
-  if (triggered_flags & can_handle->STATE_FLAG) {
-   can_handle->sendState();
-   global_events.clear(can_handle->STATE_FLAG);
-  }
-  if (triggered_flags & can_handle->SYNC_FLAG) {
-   can_handle->sendSync();
-   global_events.clear(can_handle->SYNC_FLAG);
-  }
-  if (triggered_flags & can_handle->RX_FLAG) {
-   can_handle->processCANRx();
-   global_events.clear(can_handle->RX_FLAG);
-  }
- }
+        /* Check for every event, process and then clear the corresponding flag */
+        if (triggered_flags & can_handle->THROTTLE_FLAG) {
+            can_handle->sendThrottle();
+            global_events.clear(can_handle->THROTTLE_FLAG);
+        }
+        if (triggered_flags & can_handle->STATE_FLAG) {
+            can_handle->sendState();
+            global_events.clear(can_handle->STATE_FLAG);
+        }
+        if (triggered_flags & can_handle->SYNC_FLAG) {
+            can_handle->sendSync();
+            global_events.clear(can_handle->SYNC_FLAG);
+        }
+        if (triggered_flags & can_handle->RX_FLAG) {
+            can_handle->processCANRx();
+            global_events.clear(can_handle->RX_FLAG);
+        }
+    }
 }
 
 /**
@@ -53,19 +55,17 @@ void do_can_processing() {
  * process received messages
  * @return 1 if error
  */
-int main()
-{
- etc_handle = new ETCController();
- can_handle = new CANWrapper(*etc_handle, global_events);
+int main() {
+    etc_handle = new ETCController();
+    can_handle = new CANWrapper(*etc_handle, global_events);
 
- Thread high_priority_thread(osPriorityHigh);
- high_priority_thread.start(do_can_processing);
+    Thread high_priority_thread(osPriorityHigh);
+    high_priority_thread.start(do_can_processing);
 
- while(true) {
-  /* update the etc-sensor readings */
-  etc_handle->updatePedalTravel();
- }
+    while (true) {
+        /* update the etc-sensor readings */
+        etc_handle->updatePedalTravel();
+    }
 
- return 0;
+    return 0;
 }
-

--- a/ETC/src/can_wrapper.cpp
+++ b/ETC/src/can_wrapper.cpp
@@ -8,10 +8,8 @@
  * Reads off CAN msg and then composes ETCState struct to updateStateFromCAN(ETCState& state)
  */
 void CANWrapper::processCANRx() {
-    if(CANMessage rx; mainBus->read(rx)) {
-
+    if (CANMessage rx; mainBus->read(rx)) {
     }
-    if(CANMessage rx; motorBus->read(rx)) {
-
+    if (CANMessage rx; motorBus->read(rx)) {
     }
 }

--- a/ETC/src/can_wrapper.h
+++ b/ETC/src/can_wrapper.h
@@ -5,17 +5,16 @@
 #ifndef CAN_WRAPPER_H
 #define CAN_WRAPPER_H
 
+#include "../mbed-os/mbed.h"
 #include "etc_controller.h"
 #include "module.h"
-#include "../mbed-os/mbed.h"
 
 /**
  * Holds motor and main CAN bus, composes and handles routine CAN message, handles CAN Rx as well
  */
 class CANWrapper : public Module {
-
-    CAN* mainBus; // to be initialized
-    CAN* motorBus; // to be initialized
+    CAN* mainBus;   // to be initialized
+    CAN* motorBus;  // to be initialized
     EventFlags& Global_Events;
     ETCController& etc;
     Ticker throttleTicker;
@@ -30,25 +29,27 @@ class CANWrapper : public Module {
     constexpr static PinName MOTOR_BUS_TD = PA_12;
 
 public:
-
     const int32_t THROTTLE_FLAG = (1UL << 0);
     const int32_t SYNC_FLAG = (1UL << 1);
     const int32_t STATE_FLAG = (1UL << 2);
     const int32_t RX_FLAG = (1UL << 3);
 
-
-    CANWrapper(ETCController& etcController, EventFlags& events) : Global_Events(events), etc(etcController) {
+    CANWrapper(ETCController& etcController, EventFlags& events)
+        : Global_Events(events),
+          etc(etcController) {
         /* Attempt CAN connections */
 
-        //TODO add fail code for failed CAN instantiation
+        // TODO add fail code for failed CAN instantiation
         mainBus = new CAN(MAIN_BUS_RD, MAIN_BUS_TD, CAN_FREQ);
         motorBus = new CAN(MOTOR_BUS_RD, MOTOR_BUS_TD, CAN_FREQ);
 
         /* start regular ISR routine for sending*/
         throttleTicker.attach(callback([this]() {
-            //NOTE that we do 1 sec interval for testing it should rly be 100ms
-            Global_Events.set(THROTTLE_FLAG);
-            }), 1s);
+                                  // NOTE that we do 1 sec interval for testing it should rly be
+                                  // 100ms
+                                  Global_Events.set(THROTTLE_FLAG);
+                              }),
+                              1s);
         //
         // syncTicker.attach(callback([this]() {
         //     Global_Events.set(THROTTLE_FLAG);
@@ -59,29 +60,21 @@ public:
         //     }), 100ms);
 
         /* Set up CAN RX ISR */
-        mainBus->attach(callback([this]() {
-            Global_Events.set(RX_FLAG);
-            }));
-        motorBus->attach(callback([this]() {
-            Global_Events.set(RX_FLAG);
-            }));
-
+        mainBus->attach(callback([this]() { Global_Events.set(RX_FLAG); }));
+        motorBus->attach(callback([this]() { Global_Events.set(RX_FLAG); }));
     }
 
-
-    //TODO move definitions to .cpp file
+    // TODO move definitions to .cpp file
     /**
-    * Sends throttle data to the CANBus
-    *
-    * NOTE* Sends 0 for torque demand until start conditions are met
-    */
+     * Sends throttle data to the CANBus
+     *
+     * NOTE* Sends 0 for torque demand until start conditions are met
+     */
     void sendThrottle() {
         etc.updateMBBAlive();
 
-        auto [mbb_alive, he1_read, he2_read,
-            he1_travel, he2_travel, pedal_travel,
-            brakes_read, ts_ready, motor_enabled,
-            motor_forward, cockpit, torque_demand] = etc.getState();
+        auto [mbb_alive, he1_read, he2_read, he1_travel, he2_travel, pedal_travel, brakes_read,
+              ts_ready, motor_enabled, motor_forward, cockpit, torque_demand] = etc.getState();
 
         CANMessage throttleMessage;
         throttleMessage.id = 0x186;
@@ -90,29 +83,30 @@ public:
         throttleMessage.data[1] = torque_demand >> 8;
         throttleMessage.data[2] = etc.getMaxSpeed();
         throttleMessage.data[3] = etc.getMaxSpeed() >> 8;
-        throttleMessage.data[4] = 0x00 | (0x01 & motor_forward) | ((0x01 & !motor_forward) << 1) | ((0x01 & motor_enabled) << 3);
+        throttleMessage.data[4] = 0x00 | (0x01 & motor_forward) | ((0x01 & !motor_forward) << 1) |
+                                  ((0x01 & motor_enabled) << 3);
         throttleMessage.data[5] = 0x00 | (0x0f & mbb_alive);
         throttleMessage.data[6] = 0x00;
         throttleMessage.data[7] = 0x00;
 
-        //motorBus->write(throttleMessage);
+        // motorBus->write(throttleMessage);
         printf("Sending Throttle...");
-    };
+    }
 
     void sendSync() {
         unsigned char data[0];
         CANMessage syncMessage(0x80, data, 0);
-        //send syncMessage
-    };
+        // send syncMessage
+    }
 
     void sendState() {
-
         ETCState state = etc.getState();
 
         CANMessage stateMessage;
         stateMessage.id = 0x1A1;
 
-        stateMessage.data[0] = 0x00 | (0x01 & etc.isTSReady()) | ((0x01 & etc.isMotorEnabled()) << 1) | ((0x01 & state.cockpit << 4));
+        stateMessage.data[0] = 0x00 | (0x01 & etc.isTSReady()) |
+                               ((0x01 & etc.isMotorEnabled()) << 1) | ((0x01 & state.cockpit << 4));
         stateMessage.data[1] = static_cast<int8_t>(state.brakes_read * 100);
         stateMessage.data[2] = static_cast<int8_t>(state.he1_read * 100);
         stateMessage.data[3] = static_cast<int8_t>(state.he2_read * 100);
@@ -120,7 +114,7 @@ public:
         stateMessage.data[5] = static_cast<int8_t>(state.he2_travel * 100);
         stateMessage.data[6] = static_cast<int8_t>(state.pedal_travel * 100);
         stateMessage.data[7] = 0x00;
-    };
+    }
 
     /**
      * Parse CAN msg and then run ETC updateStateFromCAN and provide parameters
@@ -128,4 +122,4 @@ public:
     void processCANRx();
 };
 
-#endif //CAN_WRAPPER_H
+#endif  // CAN_WRAPPER_H

--- a/ETC/src/etc_controller.cpp
+++ b/ETC/src/etc_controller.cpp
@@ -4,7 +4,7 @@
 
 #include "etc_controller.h"
 
-//TODO make the function :)))
+// TODO make the function :)))
 void ETCController::updatePedalTravel() {
     /* read HE1 and HE2 sensors */
 
@@ -20,11 +20,9 @@ void ETCController::updateMBBAlive() {
     state.mbb_alive %= 16;
 }
 
-void ETCController::updateStateFromCAN(const ETCState& new_state) {
-    state = new_state;
-}
+void ETCController::updateStateFromCAN(const ETCState& new_state) { state = new_state; }
 
-//TODO make function : )
+// TODO make function : )
 void ETCController::checkStartConditions() {
     /* this function is already set up to run when the cockpit is switched on */
 
@@ -33,11 +31,8 @@ void ETCController::checkStartConditions() {
     /* if all that is happening switch motor_on to true */
 }
 
-//TODO make function :)
-void ETCController::runRTDS() {
-    /* Run RTDS for 3 seconds */
-}
-
+// TODO make function :)
+void ETCController::runRTDS() { /* Run RTDS for 3 seconds */ }
 
 void ETCController::resetState() {
     state.mbb_alive = 0;

--- a/ETC/src/etc_controller.h
+++ b/ETC/src/etc_controller.h
@@ -5,9 +5,8 @@
 #ifndef ETC_CONTROLLER_H
 #define ETC_CONTROLLER_H
 
-#include "module.h"
 #include "../mbed-os/mbed.h"
-
+#include "module.h"
 
 struct ETCState {
     uint8_t mbb_alive;
@@ -25,7 +24,6 @@ struct ETCState {
 };
 
 class ETCController {
-    
     // Digital and Analog Inputs/Outputs
     AnalogIn HE1;
     AnalogIn HE2;
@@ -46,30 +44,26 @@ class ETCController {
 public:
     // Constructor
     ETCController()
-        : HE1(PA_0), HE2(PB_0), Brakes(PC_0),
-          Cockpit(PH_1), Reverse(PC_15), RTDS(PC_13) {
-
+        : HE1(PA_0),
+          HE2(PB_0),
+          Brakes(PC_0),
+          Cockpit(PH_1),
+          Reverse(PC_15),
+          RTDS(PC_13) {
         resetState();
 
         /* ADD ISR for Cockpit and Reverse */
-        Cockpit.rise(callback([this]() {
-            turnOffMotor();
-        }));
-        Cockpit.fall(callback([this]() {
-            checkStartConditions();
-        }));
-        Reverse.rise(callback([this]() {
-            switchForwardMotor();
-        }));
-        Reverse.fall(callback([this]() {
-            switchReverseMotor();
-        }));
+        Cockpit.rise(callback([this]() { turnOffMotor(); }));
+        Cockpit.fall(callback([this]() { checkStartConditions(); }));
+        Reverse.rise(callback([this]() { switchForwardMotor(); }));
+        Reverse.fall(callback([this]() { switchReverseMotor(); }));
     }
 
     // Member Functions
 
     /**
-     * Read Hall Effect Sensors and then update ETC State. Checks implausibility also and starts timer.
+     * Read Hall Effect Sensors and then update ETC State. Checks implausibility also and starts
+     * timer.
      */
     void updatePedalTravel();
 
@@ -90,7 +84,8 @@ public:
     void resetState();
 
     /**
-     *  Runs on falling cockpit switch, checks if brakes are pressed and TS is ready, then switches motor_enabled to true
+     *  Runs on falling cockpit switch, checks if brakes are pressed and TS is ready, then switches
+     * motor_enabled to true
      */
     void checkStartConditions();
 
@@ -100,28 +95,29 @@ public:
     void runRTDS();
 
     // Accessors
-    [[nodiscard]] uint8_t getMBBAlive() const { return state.mbb_alive; };
-    [[nodiscard]] float getBrakes() const { return state.brakes_read; };
-    [[nodiscard]] float getHE1Read() const { return state.he1_read; };
-    [[nodiscard]] float getHE2Read() const { return state.he2_read; };
-    [[nodiscard]] float getHE1Travel() const { return state.he1_travel; };
-    [[nodiscard]] float getHE2Travel() const { return state.he2_travel; };
-    [[nodiscard]] float getPedalTravel() const { return state.pedal_travel; };
-    [[nodiscard]] int16_t getTorqueDemand() const { return state.motor_enabled ? state.torque_demand : 0; };
-    [[nodiscard]] int16_t getMaxSpeed() const { return MAX_SPEED; };
+    [[nodiscard]] uint8_t getMBBAlive() const { return state.mbb_alive; }
+    [[nodiscard]] float getBrakes() const { return state.brakes_read; }
+    [[nodiscard]] float getHE1Read() const { return state.he1_read; }
+    [[nodiscard]] float getHE2Read() const { return state.he2_read; }
+    [[nodiscard]] float getHE1Travel() const { return state.he1_travel; }
+    [[nodiscard]] float getHE2Travel() const { return state.he2_travel; }
+    [[nodiscard]] float getPedalTravel() const { return state.pedal_travel; }
+    [[nodiscard]] int16_t getTorqueDemand() const {
+        return state.motor_enabled ? state.torque_demand : 0;
+    }
+    [[nodiscard]] int16_t getMaxSpeed() const { return MAX_SPEED; }
 
-    [[nodiscard]] bool isMotorForward() const { return state.motor_forward; };
-    [[nodiscard]] bool isMotorEnabled() const { return state.motor_enabled; };
-    [[nodiscard]] bool isTSReady() const { return state.ts_ready; };
-    [[nodiscard]] bool isCockpit() const { return state.cockpit; };
+    [[nodiscard]] bool isMotorForward() const { return state.motor_forward; }
+    [[nodiscard]] bool isMotorEnabled() const { return state.motor_enabled; }
+    [[nodiscard]] bool isTSReady() const { return state.ts_ready; }
+    [[nodiscard]] bool isCockpit() const { return state.cockpit; }
 
-    [[nodiscard]] ETCState getState() const { return state; };
+    [[nodiscard]] ETCState getState() const { return state; }
 
-    void switchReverseMotor() {state.motor_forward = false;};
-    void switchForwardMotor() {state.motor_forward = true;}
+    void switchReverseMotor() { state.motor_forward = false; }
+    void switchForwardMotor() { state.motor_forward = true; }
 
-    void turnOffMotor() {state.motor_enabled = false;}
-
+    void turnOffMotor() { state.motor_enabled = false; }
 };
 
-#endif //ETC_CONTROLLER_H
+#endif  // ETC_CONTROLLER_H

--- a/ETC/src/module.h
+++ b/ETC/src/module.h
@@ -8,8 +8,8 @@
 #include <cstdint>
 
 /**
-* Base class for modules containing error codes.
-*/
+ * Base class for modules containing error codes.
+ */
 class Module {
 public:
     static constexpr int32_t MOD_ERR_ARG = -1;
@@ -18,6 +18,5 @@ public:
     static constexpr int32_t MOD_ERR_BAD_CMD = -4;
     static constexpr int32_t MOD_ERR_BUF_OVERRUN = -5;
     static constexpr int32_t MOD_ERR_BAD_INSTANCE = -6;
-
 };
-#endif //MODULE_H
+#endif  // MODULE_H


### PR DESCRIPTION
## Synopsis
### Added
* Add a .clang-format file that generally follows from the Google C++ style guide. Google style was chosen both because of its popularity and its similarity to existing conventions in the ETC code.
### Changed
* Ran clang-format through the current ETC codebase (`main.cpp`, `src`). No functional changes were made, only style