### PR TITLE
ETC brake signal output pin

### DIFF
--- a/ETC/CMakeLists.txt
+++ b/ETC/CMakeLists.txt
@@ -18,7 +18,8 @@ project(ETC)
 
 
 # Main ETC executable target
-add_executable(ETC main.cpp src/can_wrapper.cpp src/etc_controller.cpp)
+set(SRC_CPP_FILES src/can_wrapper.cpp src/etc_controller.cpp)
+add_executable(ETC main.cpp ${SRC_CPP_FILES})
 target_include_directories(ETC PRIVATE mbed-os)
 target_link_libraries(ETC mbed-os)
 mbed_set_post_build(ETC)
@@ -33,8 +34,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(unity)
 
-add_executable(ETC-unittests tests/test_main.cpp)
+add_executable(ETC-unittests tests/test_main.cpp ${SRC_CPP_FILES})
 target_include_directories(ETC-unittests PRIVATE
+  src
   tests
   mbed-os
   ${unity_SOURCE_DIR}/src

--- a/ETC/src/etc_controller.cpp
+++ b/ETC/src/etc_controller.cpp
@@ -20,7 +20,17 @@ void ETCController::updateMBBAlive() {
     state.mbb_alive %= 16;
 }
 
-void ETCController::updateStateFromCAN(const ETCState& new_state) { state = new_state; }
+void ETCController::updateStateFromCAN(const ETCState& new_state) {
+    state = new_state;
+
+    // Perform actions that occur on each state update.
+    this->updateBrakeSignal();
+}
+
+void ETCController::updateBrakeSignal() {
+    bool brake_light_on = this->state.brakes_read > this->BRAKE_TOL;
+    this->BrakesOut.write(brake_light_on);
+}
 
 // TODO make function : )
 void ETCController::checkStartConditions() {

--- a/ETC/src/etc_controller.h
+++ b/ETC/src/etc_controller.h
@@ -30,18 +30,19 @@ class ETCController {
     AnalogIn Brakes;
     InterruptIn Cockpit;
     InterruptIn Reverse;
+    DigitalOut BrakesOut;
     DigitalOut RTDS;
 
+    // State Variables
+    ETCState state{0};
+
+public:
     // Constants
     const int16_t MAX_SPEED = 7500;
     const int16_t MAX_TORQUE = 30000;
     const float MAX_V = 3.3;
     const float BRAKE_TOL = 0.1;
 
-    // State Variables
-    ETCState state{0};
-
-public:
     // Constructor
     ETCController()
         : HE1(PA_0),
@@ -49,6 +50,7 @@ public:
           Brakes(PC_0),
           Cockpit(PH_1),
           Reverse(PC_15),
+          BrakesOut(PC_14),
           RTDS(PC_13) {
         resetState();
 
@@ -77,6 +79,11 @@ public:
      * @param new_state
      */
     void updateStateFromCAN(const ETCState& new_state);
+
+    /**
+     * Updates the digital output signal on the brake light pin based on the current ETC state.
+     */
+    void updateBrakeSignal();
 
     /**
      * Reset state to default values

--- a/ETC/tests/test_main.cpp
+++ b/ETC/tests/test_main.cpp
@@ -15,11 +15,16 @@
 
 
 // Include other test files here. Remember to add test cases to the "run_all_tests" function!
+#include "test_update_brake_signal.h"
 
 // Standard headers begin here
+#include "test_main.h"
 #include "mbed.h"
 #include "unity.h"
 #include <iostream>
+
+
+ETCController *etcController;
 
 
 /**
@@ -27,6 +32,8 @@
  */
 void run_all_tests() {
     // Use the RUN_TEST(<function_name>) macro here
+    RUN_TEST(test_brake_pin_full_voltage_range);
+    RUN_TEST(test_brake_range_boundary);
 }
 
 
@@ -36,7 +43,7 @@ void run_all_tests() {
  * DO NOT MODIFY! If you are just adding new tests, read the header comment in this file.
  */
 void setUp() {
-    // Do nothing
+    etcController = new ETCController();
 }
 
 
@@ -46,7 +53,7 @@ void setUp() {
  * DO NOT MODIFY! If you are just adding new tests, read the header comment in this file.
  */
 void tearDown() {
-    // Do nothing
+    delete etcController;
 }
 
 

--- a/ETC/tests/test_main.h
+++ b/ETC/tests/test_main.h
@@ -1,0 +1,11 @@
+#ifndef _TEST_MAIN_H_
+#define _TEST_MAIN_H_
+
+
+#include "etc_controller.h"
+
+
+extern ETCController *etcController;
+
+
+#endif  // _TEST_MAIN_H_

--- a/ETC/tests/test_template.h.template
+++ b/ETC/tests/test_template.h.template
@@ -2,6 +2,7 @@
 #define _TEST_TEMPLATE_H_
 
 
+#include "test_main.h"
 #include "unity.h"
 
 /* TODO: Include ETC source header files here as needed to test their components. */
@@ -11,4 +12,4 @@
 /* TODO: Write test functions here. */
 
 
-#endif  // TEST_TEMPLATE_H_
+#endif  // _TEST_TEMPLATE_H_

--- a/ETC/tests/test_update_brake_signal.h
+++ b/ETC/tests/test_update_brake_signal.h
@@ -1,0 +1,41 @@
+#ifndef _TEST_UPDATE_BRAKE_SIGNAL_H_
+#define _TEST_UPDATE_BRAKE_SIGNAL_H_
+
+
+#include "test_main.h"
+#include "etc_controller.h"
+#include "mbed.h"
+#include "unity.h"
+#include <iostream>
+
+
+void test_brake_pin_full_voltage_range() {
+    DigitalOut brake_signal_pin(PC_14);
+
+    for (float brake_voltage = 0.0; brake_voltage < etcController->MAX_V; brake_voltage += 0.05) {
+        ETCState new_state = {.brakes_read = brake_voltage};
+        etcController->updateStateFromCAN(new_state);
+
+        TEST_ASSERT_EQUAL(brake_signal_pin.read(), brake_voltage > etcController->BRAKE_TOL);
+    }
+}
+
+void test_brake_range_boundary() {
+    DigitalOut brake_signal_pin(PC_14);
+    ETCState etc_state;
+
+    etc_state.brakes_read = etcController->BRAKE_TOL - 0.01;
+    etcController->updateStateFromCAN(etc_state);
+    TEST_ASSERT_EQUAL(brake_signal_pin.read(), false);
+
+    etc_state.brakes_read = etcController->BRAKE_TOL;
+    etcController->updateStateFromCAN(etc_state);
+    TEST_ASSERT_EQUAL(brake_signal_pin.read(), false);
+
+    etc_state.brakes_read = etcController->BRAKE_TOL + 0.01;
+    etcController->updateStateFromCAN(etc_state);
+    TEST_ASSERT_EQUAL(brake_signal_pin.read(), true);
+}
+
+
+#endif  // _TEST_UPDATE_BRAKE_SIGNAL_H_


### PR DESCRIPTION
## Synopsis
### Added
* Add `BrakesOut` as a digital output pin to the ETC controller class
* Add an `updateBrakeSignal` function to the ETC controller class that is called when the ETC state is updated
### Changed
* Improve unit test driver code (add `etcController` pointer for convenience, update template)