### PR TITLE
Add code formatters for Telemetry

### DIFF
--- a/telemetry/.clang-format
+++ b/telemetry/.clang-format
@@ -1,0 +1,274 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: None
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+BreakTemplateDeclarations: MultiLine
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/telemetry/.githooks/pre-commit
+++ b/telemetry/.githooks/pre-commit
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+# Styling
+BOLD="\033[1m"
+GREEN="\033[0;32m"
+NC="\033[0m"
+
+# Header
+printf "${BOLD}${GREEN}\n"
+printf "=====================================\n"
+printf "      FS-3 Telemetry Code Checks     \n"
+printf "=====================================\n"
+printf "${NC}"
+
+# Get staged files
+FILES=$(git diff --cached --name-only --diff-filter=ACM)
+FORMATTABLE_FILES=$(printf "%s\n" "$FILES" | grep -E '\.(c|cpp|h|hpp|js|ts|jsx|tsx|html|css|json|md|yaml|yml)$' || true)
+TOTAL=$(printf "%s\n" "$FORMATTABLE_FILES" | wc -l | tr -d ' ')
+
+[ "$TOTAL" -eq 0 ] && {
+    echo "${GREEN}✅ No files to format. You're good to go!${NC}"
+    exit 0
+}
+
+# Format loop
+INDEX=1
+printf "%s\n" "$FORMATTABLE_FILES" | while IFS= read -r FILE; do
+    TOOL=""
+    case "$FILE" in
+        *.c|*.cpp|*.h|*.hpp)
+            TOOL="🔧 clang-format"
+            clang-format -i "$FILE" >/dev/null 2>&1
+            ;;
+        *.js|*.ts|*.jsx|*.tsx|*.html|*.css|*.json|*.md|*.yaml|*.yml)
+            TOOL="🎨 prettier"
+            npx prettier --write "$FILE" >/dev/null 2>&1
+            ;;
+    esac
+
+    git add "$FILE"
+    printf "[%d/%d] %s: %s\n" "$INDEX" "$TOTAL" "$TOOL" "$FILE"
+    INDEX=$((INDEX + 1))
+done
+
+# Final message
+echo "\n${BOLD}${GREEN}✅ All formatted! Pre-commit complete.\n"

--- a/telemetry/.prettierrc
+++ b/telemetry/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": false,
+  "singleQuote": true
+}

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,6 @@
+# FS-3 Telemetry
+
+## Setup (git hooks)
+1. `chmod +x setup-hooks.sh`
+2. `./setup-hooks.sh`
+3. Go ahead and `git add <files>` and `git commit`!

--- a/telemetry/setup-hooks.sh
+++ b/telemetry/setup-hooks.sh
@@ -1,4 +1,31 @@
-# telemetry/setup-hooks.sh
-#!/bin/bash
-ln -sf ../../telemetry/hooks/pre-commit .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+#!/bin/sh
+set -e
+
+HOOK_SOURCE="telemetry/hooks/pre-commit"
+HOOK_TARGET=".git/hooks/pre-commit"
+
+echo "🛠️  FS-3 Telemetry: Pre-Commit Hook Setup"
+
+# Does source hook exist?
+if [ ! -f "$HOOK_SOURCE" ]; then
+  echo "❌ Error: Cannot find hook source at $HOOK_SOURCE"
+  exit 1
+fi
+
+# Create .git/hooks if needed
+if [ ! -d ".git/hooks" ]; then
+  echo "📂 Creating .git/hooks directory..."
+  mkdir -p .git/hooks
+fi
+
+# Symlink the hook
+echo "🔗 Linking $HOOK_SOURCE → $HOOK_TARGET"
+ln -sf "../../$HOOK_SOURCE" "$HOOK_TARGET"
+
+# Make it executable
+echo "🔒 Making hook executable"
+chmod +x "$HOOK_TARGET"
+
+# Finish up
+echo "✅ Pre-commit hook installed!"
+echo "🚦 Try staging a file and running: git commit -m 'Test'"

--- a/telemetry/setup-hooks.sh
+++ b/telemetry/setup-hooks.sh
@@ -1,0 +1,4 @@
+# telemetry/setup-hooks.sh
+#!/bin/bash
+ln -sf ../../telemetry/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
As part of implementation of coding standards, I'd like to add code formatters to this repo for both embedded and frontend work. Embedded uses Google's .clang-format file, and frontend uses [the basic .prettierrc file given by prettier on their site](https://prettier.io/docs/configuration#basic-configuration).